### PR TITLE
Add SQLite database setup script and tests

### DIFF
--- a/catalog-sync/README.md
+++ b/catalog-sync/README.md
@@ -1,1 +1,8 @@
 # Shopify-Amazon Bridge
+
+This project aims to sync product data between Shopify and Amazon.
+
+## Database Setup
+
+Run `python catalog_sync/database.py` to create a local SQLite database
+`catalog.db` containing a `products` table indexed by Shopify ID and SKU.

--- a/catalog-sync/catalog_sync/database.py
+++ b/catalog-sync/catalog_sync/database.py
@@ -1,0 +1,31 @@
+import sqlite3
+from sqlite3 import Connection
+from pathlib import Path
+
+DB_FILENAME = "catalog.db"
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS products (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    shopify_id TEXT,
+    sku TEXT UNIQUE,
+    title TEXT,
+    description TEXT,
+    price REAL,
+    quantity INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_products_shopify_id ON products(shopify_id);
+"""
+
+
+def initialize_db(db_path: str = DB_FILENAME) -> Connection:
+    """Initialize the SQLite database and return the connection."""
+    path = Path(db_path)
+    conn = sqlite3.connect(path)
+    with conn:
+        conn.executescript(SCHEMA_SQL)
+    return conn
+
+
+if __name__ == "__main__":
+    initialize_db()

--- a/catalog-sync/tests/test_database.py
+++ b/catalog-sync/tests/test_database.py
@@ -1,0 +1,26 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+# Ensure catalog-sync package is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from catalog_sync import database
+
+def test_initialize_db(tmp_path):
+    db_path = tmp_path / 'test.db'
+    conn = database.initialize_db(str(db_path))
+    conn.close()
+
+    assert db_path.exists()
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    cursor.execute("PRAGMA table_info(products)")
+    columns = [row[1] for row in cursor.fetchall()]
+    assert 'id' in columns and 'sku' in columns
+
+    cursor.execute("PRAGMA index_list(products)")
+    indexes = [row[1] for row in cursor.fetchall()]
+    assert 'idx_products_shopify_id' in indexes
+    conn.close()


### PR DESCRIPTION
## Summary
- add `catalog_sync/database.py` for initializing SQLite database
- add tests for database initialization
- document database setup in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409dc33c64832fa85aba883af9d5df